### PR TITLE
Revert "ONBUILD removes the needs to add "ADD . /var/www" in children…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ COPY config/supervisord/conf.d /etc/supervisor/conf.d
 
 WORKDIR /var/www
 
-ONBUILD ADD . /var/www
-
 EXPOSE 80
 
 CMD ["/usr/bin/supervisord", "-n"]


### PR DESCRIPTION
… Dockerfile"

This is generating too much cache invalidation

This reverts commit f75ee6958633d1d2b222a03267ca3ee3af739845.
