### PR TITLE
add mbstring and git in all versions

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-ins
     supervisor \
     ca-certificates \
     nginx \
+    git \
     php5 \
     php5-cli \
     php5-intl \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get -qq update > /dev/null && DEBIAN_FRONTEND=noninteractive apt-get -qq
     supervisor \
     ca-certificates \
     nginx \
+    git \
     php5 \
     php5-cli \
     php5-intl \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get -qq update > /dev/null && DEBIAN_FRONTEND=noninteractive apt-get -qq
     supervisor \
     ca-certificates \
     nginx \
+    git \
     wget > /dev/null &&\
     echo "deb http://packages.dotdeb.org jessie all" > /etc/apt/sources.list.d/dotdeb.list && \
     wget -O- https://www.dotdeb.org/dotdeb.gpg | apt-key add - && \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get -qq update > /dev/null && DEBIAN_FRONTEND=noninteractive apt-get -qq
     ca-certificates \
     nginx \
     wget \
-    git \
     apt-transport-https > /dev/null &&\
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg &&\
     echo "deb https://packages.sury.org/php/ jessie main" > /etc/apt/sources.list.d/php.list &&\
@@ -21,6 +20,7 @@ RUN apt-get -qq update > /dev/null && DEBIAN_FRONTEND=noninteractive apt-get -qq
     php7.1-intl \
     php7.1-fpm \
     php7.1-xml \
+    php7.1-mbstring \
     php7.1-zip > /dev/null &&\
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&\

--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ COPY custom-config.conf /etc/nginx/conf.d/docker/custom-config.conf
 ### Minimal package included
 
 * nginx
-* php5-fpm
-* php5-cli
-* php5-intl
+* php\*-fpm
+* php\*-cli
+* php\*-intl
+* php\*-mbstring
 
 ### Exposed port
 * 80 : nginx


### PR DESCRIPTION
git shouldn't be necessary and mbstring is required for phpunit (and is present in the 7.0 dockerfile)