### PR TITLE
Remove useless services

### DIFF
--- a/7.0/rootfs/etc/supervisor/conf.d/app-log.conf
+++ b/7.0/rootfs/etc/supervisor/conf.d/app-log.conf
@@ -2,3 +2,9 @@
 command=/bin/bash -c "tail -q -n 0 -F app/logs/dev.log app/logs/prod.log var/logs/dev.log var/logs/prod.log"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
+
+[program:php-fpm-logs]
+command=/usr/bin/tail -q -n 0 --follow=descriptor --retry %(ENV_LOG_STREAM)s
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+redirect_stderr=true

--- a/7.0/rootfs/etc/supervisor/conf.d/app-log.conf
+++ b/7.0/rootfs/etc/supervisor/conf.d/app-log.conf
@@ -1,5 +1,5 @@
 [program:app-log]
-command=/bin/bash -c "tail -q -n 0 -F app/logs/dev.log app/logs/prod.log var/logs/dev.log var/logs/prod.log"
+command=/usr/bin/tail -q -n 0 -F app/logs/dev.log app/logs/prod.log var/logs/dev.log var/logs/prod.log
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 

--- a/7.0/rootfs/etc/supervisor/conf.d/app-log.conf
+++ b/7.0/rootfs/etc/supervisor/conf.d/app-log.conf
@@ -1,4 +1,4 @@
 [program:app-log]
-command=/bin/bash -c "tail -q -n 0 -F app/logs/dev.log app/logs/prod.log var/logs/dev.log var/logs/prod.log %(ENV_LOG_STREAM)s"
+command=/bin/bash -c "tail -q -n 0 -F app/logs/dev.log app/logs/prod.log var/logs/dev.log var/logs/prod.log"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/7.0/rootfs/etc/supervisor/conf.d/php-fpm.conf
+++ b/7.0/rootfs/etc/supervisor/conf.d/php-fpm.conf
@@ -4,8 +4,3 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 
-[program:php-fpm-logs]
-command=/usr/bin/tail -q -n 0 --follow=descriptor --retry %(ENV_LOG_STREAM)s
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-redirect_stderr=true

--- a/7.1/rootfs/etc/supervisor/conf.d/app-log.conf
+++ b/7.1/rootfs/etc/supervisor/conf.d/app-log.conf
@@ -2,3 +2,9 @@
 command=/bin/bash -c "tail -q -n 0 -F app/logs/dev.log app/logs/prod.log var/logs/dev.log var/logs/prod.log"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
+
+[program:php-fpm-logs]
+command=/usr/bin/tail -q -n 0 --follow=descriptor --retry %(ENV_LOG_STREAM)s
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+redirect_stderr=true

--- a/7.1/rootfs/etc/supervisor/conf.d/app-log.conf
+++ b/7.1/rootfs/etc/supervisor/conf.d/app-log.conf
@@ -1,5 +1,5 @@
 [program:app-log]
-command=/bin/bash -c "tail -q -n 0 -F app/logs/dev.log app/logs/prod.log var/logs/dev.log var/logs/prod.log"
+command=/usr/bin/tail -q -n 0 -F app/logs/dev.log app/logs/prod.log var/logs/dev.log var/logs/prod.log
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 

--- a/7.1/rootfs/etc/supervisor/conf.d/app-log.conf
+++ b/7.1/rootfs/etc/supervisor/conf.d/app-log.conf
@@ -1,4 +1,4 @@
 [program:app-log]
-command=/bin/bash -c "tail -q -n 0 -F app/logs/dev.log app/logs/prod.log var/logs/dev.log var/logs/prod.log %(ENV_LOG_STREAM)s"
+command=/bin/bash -c "tail -q -n 0 -F app/logs/dev.log app/logs/prod.log var/logs/dev.log var/logs/prod.log"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/7.1/rootfs/etc/supervisor/conf.d/php-fpm.conf
+++ b/7.1/rootfs/etc/supervisor/conf.d/php-fpm.conf
@@ -4,8 +4,3 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 
-[program:php-fpm-logs]
-command=/usr/bin/tail -q -n 0 --follow=descriptor --retry %(ENV_LOG_STREAM)s
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-redirect_stderr=true

--- a/7.2/rootfs/etc/supervisor/conf.d/app-log.conf
+++ b/7.2/rootfs/etc/supervisor/conf.d/app-log.conf
@@ -2,3 +2,9 @@
 command=/bin/bash -c "tail -q -n 0 -F app/logs/dev.log app/logs/prod.log var/logs/dev.log var/logs/prod.log"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
+
+[program:php-fpm-logs]
+command=/usr/bin/tail -q -n 0 --follow=descriptor --retry %(ENV_LOG_STREAM)s
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+redirect_stderr=true

--- a/7.2/rootfs/etc/supervisor/conf.d/app-log.conf
+++ b/7.2/rootfs/etc/supervisor/conf.d/app-log.conf
@@ -1,5 +1,5 @@
 [program:app-log]
-command=/bin/bash -c "tail -q -n 0 -F app/logs/dev.log app/logs/prod.log var/logs/dev.log var/logs/prod.log"
+command=/usr/bin/tail -q -n 0 -F app/logs/dev.log app/logs/prod.log var/logs/dev.log var/logs/prod.log
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 

--- a/7.2/rootfs/etc/supervisor/conf.d/app-log.conf
+++ b/7.2/rootfs/etc/supervisor/conf.d/app-log.conf
@@ -1,4 +1,4 @@
 [program:app-log]
-command=/bin/bash -c "tail -q -n 0 -F app/logs/dev.log app/logs/prod.log var/logs/dev.log var/logs/prod.log %(ENV_LOG_STREAM)s"
+command=/bin/bash -c "tail -q -n 0 -F app/logs/dev.log app/logs/prod.log var/logs/dev.log var/logs/prod.log"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
Move service of`$LOG_STREAM` to `app-logs.conf`.

When overriding `php-fpm.conf` (to disable php-fpm in case of a queue consumer container) we also disable tailing `$LOG_STREAM` which cause execution freeze, see 89190829bc4cbecdf600966b4341347424b5dceb

Also remove useless bash wrapper around tail in log services