### PR TITLE
Add PHP 8 support

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,0 +1,50 @@
+FROM debian:stretch
+
+LABEL maintainer="Kibatic system@kibatic.com"
+
+# https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV PERFORMANCE_OPTIM false
+
+RUN apt-get -qq update > /dev/null && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
+    apt-utils \
+    supervisor \
+    ca-certificates \
+    nginx \
+    wget \
+    vim \
+    git \
+    curl \
+    openssl \
+    make \
+    unzip \
+    apt-transport-https > /dev/null && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
+    echo "deb https://packages.sury.org/php/ stretch main" > /etc/apt/sources.list.d/php.list && \
+    apt-get update -qq > /dev/null && \
+    DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
+    php8.0 \
+    php8.0-cli \
+    php8.0-intl \
+    php8.0-fpm \
+    php8.0-xml \
+    php8.0-mbstring \
+    php8.0-curl > /dev/null && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    php -r "readfile('https://getcomposer.org/installer');" | php -- \
+        --install-dir=/usr/local/bin \
+        --filename=composer && \
+    echo "daemon off;" >> /etc/nginx/nginx.conf && \
+    mkdir -p /run/php
+
+COPY rootfs /
+
+WORKDIR /var/www
+
+EXPOSE 80
+
+CMD ["/entrypoint.sh"]

--- a/8.0/rootfs/entrypoint.sh
+++ b/8.0/rootfs/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+chown www-data /var/www/ /var/www/var/log
+
+SYMFONY_VERSION=${SYMFONY_VERSION:-5}
+NGINX_CONFIG=symfony$SYMFONY_VERSION
+
+# Avoid to remove a bind mounted nginx config
+NGINX_DEFAULT=/etc/nginx/sites-enabled/default
+if ! mountpoint -q $NGINX_DEFAULT; then
+  echo "Using default nginx config : $NGINX_CONFIG"
+  rm $NGINX_DEFAULT
+  ln -s /etc/nginx/sites-available/$NGINX_CONFIG.conf $NGINX_DEFAULT
+fi
+
+# Disable opcache optimisation for developpement
+# Allow files to be reloaded when update without restarting fpm process
+if [[ "$PERFORMANCE_OPTIM" = "false" ]]
+then
+  echo "Disable performance optimisation"
+  echo > /etc/php/8.0/fpm/conf.d/99-symfony.ini
+fi
+
+exec /usr/bin/supervisord -n

--- a/8.0/rootfs/etc/nginx/conf.d/docker/gzip.conf
+++ b/8.0/rootfs/etc/nginx/conf.d/docker/gzip.conf
@@ -1,0 +1,29 @@
+    gzip_comp_level 5;
+    gzip_proxied no-cache no-store private expired auth;
+    gzip_vary on;
+    gzip_types
+    application/atom+xml
+    application/javascript
+    application/json
+    application/ld+json
+    application/manifest+json
+    application/rss+xml
+    application/vnd.geo+json
+    application/vnd.ms-fontobject
+    application/font-woff
+    application/x-font-ttf
+    application/x-web-app-manifest+json
+    application/xhtml+xml
+    application/xml
+    font/opentype
+    image/bmp
+    image/svg+xml
+    image/x-icon
+    text/cache-manifest
+    text/css
+    text/plain
+    text/vcard
+    text/vnd.rim.location.xloc
+    text/vtt
+    text/x-component
+    text/x-cross-domain-policy;

--- a/8.0/rootfs/etc/nginx/conf.d/docker/logs.conf
+++ b/8.0/rootfs/etc/nginx/conf.d/docker/logs.conf
@@ -1,0 +1,2 @@
+access_log /dev/stdout docker;
+error_log /dev/stderr;

--- a/8.0/rootfs/etc/nginx/conf.d/logs.conf
+++ b/8.0/rootfs/etc/nginx/conf.d/logs.conf
@@ -1,0 +1,5 @@
+log_format docker '$remote_addr ($http_x_forwarded_for) - $remote_user [$time_local] '
+                    '"$request" $status $body_bytes_sent '
+                    '"$http_referer" "$http_user_agent"';
+
+

--- a/8.0/rootfs/etc/nginx/sites-available/symfony4.conf
+++ b/8.0/rootfs/etc/nginx/sites-available/symfony4.conf
@@ -1,0 +1,42 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server ipv6only=on;
+
+    include /etc/nginx/conf.d/docker/*.conf;
+
+    server_name localhost;
+
+    root /var/www/public;
+
+    location / {
+        # try to serve file directly, fallback to index.php
+        try_files $uri /index.php$is_args$args;
+    }
+
+    location ~ ^/index\.php(/|$) {
+        fastcgi_pass unix:/run/php/php8.0-fpm.sock;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include fastcgi_params;
+
+        # When you are using symlinks to link the document root to the
+        # current version of your application, you should pass the real
+        # application path instead of the path to the symlink to PHP
+        # FPM.
+        # Otherwise, PHP's OPcache may not properly detect changes to
+        # your PHP files (see https://github.com/zendtech/ZendOptimizerPlus/issues/126
+        # for more information).
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param DOCUMENT_ROOT $realpath_root;
+
+        # Prevents URIs that include the front controller. This will 404:
+        # http://domain.tld/index.php/some-path
+        # Remove the internal directive to allow URIs like this
+        internal;
+    }
+
+    # return 404 for all other php files not matching the front controller
+    # this prevents access to other php files you don't want to be accessible.
+    location ~ \.php$ {
+        return 404;
+    }
+}

--- a/8.0/rootfs/etc/nginx/sites-available/symfony5.conf
+++ b/8.0/rootfs/etc/nginx/sites-available/symfony5.conf
@@ -1,0 +1,42 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server ipv6only=on;
+
+    include /etc/nginx/conf.d/docker/*.conf;
+
+    server_name localhost;
+
+    root /var/www/public;
+
+    location / {
+        # try to serve file directly, fallback to index.php
+        try_files $uri /index.php$is_args$args;
+    }
+
+    location ~ ^/index\.php(/|$) {
+        fastcgi_pass unix:/run/php/php8.0-fpm.sock;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include fastcgi_params;
+
+        # When you are using symlinks to link the document root to the
+        # current version of your application, you should pass the real
+        # application path instead of the path to the symlink to PHP
+        # FPM.
+        # Otherwise, PHP's OPcache may not properly detect changes to
+        # your PHP files (see https://github.com/zendtech/ZendOptimizerPlus/issues/126
+        # for more information).
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param DOCUMENT_ROOT $realpath_root;
+
+        # Prevents URIs that include the front controller. This will 404:
+        # http://domain.tld/index.php/some-path
+        # Remove the internal directive to allow URIs like this
+        internal;
+    }
+
+    # return 404 for all other php files not matching the front controller
+    # this prevents access to other php files you don't want to be accessible.
+    location ~ \.php$ {
+        return 404;
+    }
+}

--- a/8.0/rootfs/etc/php/8.0/fpm/conf.d/99-cgi.ini
+++ b/8.0/rootfs/etc/php/8.0/fpm/conf.d/99-cgi.ini
@@ -1,0 +1,1 @@
+cgi.fix_pathinfo=0

--- a/8.0/rootfs/etc/php/8.0/fpm/conf.d/99-symfony.ini
+++ b/8.0/rootfs/etc/php/8.0/fpm/conf.d/99-symfony.ini
@@ -1,0 +1,16 @@
+; maximum memory that OPcache can use to store compiled PHP files
+opcache.memory_consumption=256
+
+; maximum number of files that can be stored in the cache
+opcache.max_accelerated_files=20000
+
+; In production servers, PHP files should never change, unless a new application version is deployed.
+; However, by default OPcache checks if cached files have changed their contents since they were cached.
+; This check introduces some overhead that can be avoided as follows:
+opcache.validate_timestamps=0
+
+; maximum memory allocated to store the results
+realpath_cache_size=4096K
+
+; save the results for 10 minutes (600 seconds)
+realpath_cache_ttl=600

--- a/8.0/rootfs/etc/php/8.0/fpm/pool.d/www_kibatic.conf
+++ b/8.0/rootfs/etc/php/8.0/fpm/pool.d/www_kibatic.conf
@@ -1,0 +1,9 @@
+[global]
+log_level = warning
+log_limit = 16384
+error_log = /dev/stderr
+
+[www]
+clear_env = no
+catch_workers_output = yes
+decorate_workers_output = no

--- a/8.0/rootfs/etc/supervisor/conf.d/nginx.conf
+++ b/8.0/rootfs/etc/supervisor/conf.d/nginx.conf
@@ -1,0 +1,6 @@
+[program:nginx]
+command=/usr/sbin/nginx
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/8.0/rootfs/etc/supervisor/conf.d/php-fpm.conf
+++ b/8.0/rootfs/etc/supervisor/conf.d/php-fpm.conf
@@ -1,0 +1,5 @@
+[program:php-fpm]
+command=/usr/sbin/php-fpm8.0 --nodaemonize
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+redirect_stderr=true

--- a/8.0/tests/Dockerfile
+++ b/8.0/tests/Dockerfile
@@ -1,0 +1,4 @@
+FROM kibatic/symfony:8.0
+
+RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive\
+    apt-get -qq -y install php8.0-sqlite3

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ If you are experiencing some issues, take a look at [TROUBLESHOOTING](TROUBLESHO
 
 Image tags follows PHP versions
 
+`latest` `8` `8.0` [(8.0/Dockerfile)](https://github.com/kibatic/symfony-docker/blob/master/8.0/Dockerfile)
 
-`latest` `7` `7.4` [(7.4/Dockerfile)](https://github.com/kibatic/symfony-docker/blob/master/7.4/Dockerfile)
+`7` `7.4` [(7.4/Dockerfile)](https://github.com/kibatic/symfony-docker/blob/master/7.4/Dockerfile)
 
 `7.3` [(7.3/Dockerfile)](https://github.com/kibatic/symfony-docker/blob/master/7.3/Dockerfile)
 
@@ -42,12 +43,19 @@ Image tags follows PHP versions
     </thead>
     <tbody>
         <tr>
-            <th rowspan="7">Image</th>
+            <th rowspan="8">Image</th>
             <td></td>
             <td>2.x</td>
             <td>3.x</td>
             <td>4.x</td>
             <td>5.x</td>
+        </tr>
+        <tr>
+            <td>7.4</td>
+            <td>:x:</td>
+            <td>:x:</td>
+            <td>:heavy_check_mark: (not tested)</td>
+            <td>:heavy_check_mark: (default)</td>
         </tr>
         <tr>
             <td>7.4</td>
@@ -96,6 +104,7 @@ Image tags follows PHP versions
 
 Composer versions :
 
+- 8.0 : 2.x
 - 7.4 : 2.x
 - 7.3 : 1.10.17
 - 7.2 : 1.10.17


### PR DESCRIPTION
Added support for PHP 8. Tested with Symfony 5 (and lots of customizations). Looks good so far!
I think you will have to add new tags to the automated builds on Docker Hub, after it's merged.

Closes https://github.com/kibatic/symfony-docker/issues/61.